### PR TITLE
Configure API base URL via Expo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ This prototype supports:
 
 10. Scan the QR code with Expo Go or run in an emulator
 
+### API Base URL configuration
+
+The React Native frontend reads its backend base URL from the Expo configuration (`extra.apiBaseUrl`). A local fallback of `http://192.168.0.6:3001` is defined in `maintenance_app/app.json`, but you should override it per environment by setting the `EXPO_PUBLIC_API_BASE_URL` environment variable before building or starting the app.
+
+- **Expo Go / local development** – create an env file such as `.env.local` that contains `EXPO_PUBLIC_API_BASE_URL=http://<your-local-ip>:3001` and run `npx expo start --env-file .env.local`. You can also prefix the command directly, for example `EXPO_PUBLIC_API_BASE_URL=http://192.168.0.6:3001 npx expo start`.
+- **EAS builds** – define the variable in `eas.json` under the `env` key for each build profile or create a secret with `eas secret:create --name EXPO_PUBLIC_API_BASE_URL --value https://api.example.com --scope project` so that the value is injected during the build.
+- **Production releases / CI** – ensure your build or update pipeline exports the variable before invoking Expo commands, e.g. `EXPO_PUBLIC_API_BASE_URL=https://api.example.com eas build --profile production` or by configuring the variable in your hosting provider's environment settings.
+
+If the default development host changes, update the fallback inside `maintenance_app/app.json` (and keep `maintenance_app/app.config.ts` aligned) so that contributors without custom environment variables can still run the project.
+
 ## Usage
 
 - Log in with your engineer account.

--- a/maintenance-forms-app-prototype/maintenance_app/app.config.ts
+++ b/maintenance-forms-app-prototype/maintenance_app/app.config.ts
@@ -1,0 +1,23 @@
+import { ConfigContext, ExpoConfig } from "expo/config";
+
+const DEFAULT_API_BASE_URL = "http://192.168.0.6:3001";
+
+type ExtraConfig = {
+  apiBaseUrl?: string;
+};
+
+export default ({ config }: ConfigContext): ExpoConfig => {
+  const fallbackApiBaseUrl =
+    (config.extra as ExtraConfig | undefined)?.apiBaseUrl ?? DEFAULT_API_BASE_URL;
+
+  return {
+    ...config,
+    name: config.name ?? "maintenance-forms-app-prototype",
+    slug: config.slug ?? "maintenance-forms-app-prototype",
+    extra: {
+      ...config.extra,
+      apiBaseUrl:
+        process.env.EXPO_PUBLIC_API_BASE_URL ?? fallbackApiBaseUrl,
+    },
+  };
+};

--- a/maintenance-forms-app-prototype/maintenance_app/app.json
+++ b/maintenance-forms-app-prototype/maintenance_app/app.json
@@ -24,6 +24,9 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
+    },
+    "extra": {
+      "apiBaseUrl": "http://192.168.0.6:3001"
     }
   }
 }

--- a/maintenance-forms-app-prototype/maintenance_app/src/config/api.ts
+++ b/maintenance-forms-app-prototype/maintenance_app/src/config/api.ts
@@ -6,10 +6,27 @@
  * author: Lukasz Brzozowski
  */
 
-import { Platform } from "react-native";
+import appConfig from "../../app.json";
 
-export const BASE_URL = Platform.select({
-  ios: "http://192.168.0.6:3001",
-  android: "http://192.168.0.6:3001",
-  default: "http://192.168.0.6:3001",
-});
+type ExtraConfig = {
+  apiBaseUrl?: string;
+};
+
+const envBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL;
+
+const fallbackBaseUrl = (appConfig.expo?.extra as ExtraConfig | undefined)?.apiBaseUrl;
+
+const resolvedBaseUrl =
+  typeof envBaseUrl === "string" && envBaseUrl.length > 0
+    ? envBaseUrl
+    : typeof fallbackBaseUrl === "string" && fallbackBaseUrl.length > 0
+      ? fallbackBaseUrl
+      : undefined;
+
+if (!resolvedBaseUrl) {
+  throw new Error(
+    "API base URL is not configured. Ensure EXPO_PUBLIC_API_BASE_URL is set or extra.apiBaseUrl is defined in app.config.ts."
+  );
+}
+
+export const BASE_URL = resolvedBaseUrl;

--- a/maintenance-forms-app-prototype/maintenance_app/tsconfig.json
+++ b/maintenance-forms-app-prototype/maintenance_app/tsconfig.json
@@ -9,9 +9,9 @@
       "@assets/*": ["assets/*"],
       "@types/*": ["data-types/*"],
       "@logic/*": ["business-logic/*"]
-
     },
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["../maintenance_service/**", "node_modules"]


### PR DESCRIPTION
## Summary
- added an Expo app.config.ts that injects `extra.apiBaseUrl` from `EXPO_PUBLIC_API_BASE_URL` with a development fallback
- read the API base URL from the Expo configuration instead of Platform-based defaults
- document how to provide the environment variable for local Expo Go, EAS builds, and production releases

## Testing
- npx tsc --noEmit