### PR TITLE
Align migration schema with runtime expectations

### DIFF
--- a/maintenance-forms-app-prototype/maintenance_service/data-layer/db/migrations/migrate.js
+++ b/maintenance-forms-app-prototype/maintenance_service/data-layer/db/migrations/migrate.js
@@ -67,32 +67,32 @@ db.exec(`
 
   -- SUBCHECK TEMPLATES
   CREATE TABLE IF NOT EXISTS subcheck_templates (
-    subcheck_template_id INTEGER PRIMARY KEY,
+    sub_template_id INTEGER PRIMARY KEY,
     item_type_id INTEGER NOT NULL,
-    subcheck_template_label TEXT NOT NULL,
-    subcheck_template_description TEXT,
+    sub_template_label TEXT NOT NULL,
+    sub_template_description TEXT,
     value_type TEXT NOT NULL CHECK (value_type IN ('TEXT','number','boolean')),
-    subcheck_template_mandatory INTEGER NOT NULL DEFAULT 1 CHECK (subcheck_template_mandatory IN (0,1)),
+    sub_template_mandatory INTEGER NOT NULL DEFAULT 1 CHECK (sub_template_mandatory IN (0,1)),
     pass_criteria TEXT,
     FOREIGN KEY (item_type_id) REFERENCES item_types(item_type_id) ON DELETE CASCADE,
-    UNIQUE (item_type_id, subcheck_template_label)
+    UNIQUE (item_type_id, sub_template_label)
   );
 
   -- SUBCHECK RESULTS
   CREATE TABLE IF NOT EXISTS subcheck_results (
-    subcheck_result_id INTEGER PRIMARY KEY,
+    sub_result_id INTEGER PRIMARY KEY,
     inspection_id INTEGER NOT NULL,
-    subcheck_template_id INTEGER NOT NULL,
-    subcheck_result_label TEXT NOT NULL,
-    subcheck_result_description TEXT,
+    sub_template_id INTEGER,
+    sub_result_label TEXT NOT NULL,
+    sub_result_description TEXT,
     value_type TEXT NOT NULL CHECK (value_type IN ('TEXT','number','boolean')),
-    subcheck_result_mandatory INTEGER NOT NULL CHECK (subcheck_result_mandatory IN (0,1)),
+    sub_result_mandatory INTEGER NOT NULL CHECK (sub_result_mandatory IN (0,1)),
     pass_criteria TEXT,
     result TEXT NOT NULL CHECK (result IN ('pass','fail','na')),
     reading_number REAL,
     reading_text TEXT,
     FOREIGN KEY (inspection_id) REFERENCES inspections(inspection_id) ON DELETE CASCADE,
-    FOREIGN KEY (subcheck_template_id) REFERENCES subcheck_templates(subcheck_template_id) ON DELETE SET NULL
+    FOREIGN KEY (sub_template_id) REFERENCES subcheck_templates(sub_template_id) ON DELETE SET NULL
   );
 
   -- RESULTS (caching result per inspection)

--- a/maintenance-forms-app-prototype/maintenance_service/dist/app.js
+++ b/maintenance-forms-app-prototype/maintenance_service/dist/app.js
@@ -135,9 +135,10 @@ app.post("/zones", (request, response) => {
         WHERE site_id=? 
         AND zone_name=?`)
             .get(siteId, zoneName.trim())?.id;
+    const name = zoneName.trim();
     response.json({
         status: "success",
-        data: { id, zone_name: zoneName.trim(), siteId }
+        data: { id, name, zone_name: name, siteId }
     });
 });
 /**
@@ -191,9 +192,10 @@ app.post("/items", (request, response) => {
         AND item_type=?
         AND item_name=?`)
             .get(zoneId, itemType.trim(), itemName.trim())?.id;
+    const name = itemName.trim();
     response.json({
         status: "success",
-        data: { id, item_name: itemName.trim(), zone_id: zoneId, item_type: itemType.trim() }
+        data: { id, name, item_name: name, zone_id: zoneId, item_type: itemType.trim() }
     });
 });
 /**
@@ -620,7 +622,7 @@ app.get("/inspections", (_request, response) => {
       SELECT 
         i.inspection_id AS id,
         i.inspection_date AS date,
-        i.category,
+        i.inspection_category AS category,
         i.item_id,
         it.item_name,
         z.zone_name AS zoneName,

--- a/maintenance-forms-app-prototype/maintenance_service/dist/libraries/InspectionManager.js
+++ b/maintenance-forms-app-prototype/maintenance_service/dist/libraries/InspectionManager.js
@@ -70,7 +70,7 @@ export class InspectionManager {
             const mandatoryRows = db
                 .prepare(`
           SELECT
-            sub_template_label, sub_template_mandatory 
+            sub_template_label, sub_template_mandatory
           FROM subcheck_templates
           WHERE item_type_id = ?`)
                 .all(typeRow.item_type_id);
@@ -86,7 +86,7 @@ export class InspectionManager {
                 .prepare(`
           INSERT INTO inspections
             (inspection_date,
-            category,
+            inspection_category,
             item_id,
             engineer_id,
             comment,
@@ -114,13 +114,13 @@ export class InspectionManager {
                 // Try to match a template by (item_type_id, sub_template_label)
                 let subcheckTemplate = db
                     .prepare(`
-            SELECT 
-              sub_template_id, 
-              value_type, 
-              sub_template_mandatory, 
+            SELECT
+              sub_template_id,
+              value_type,
+              sub_template_mandatory,
               pass_criteria
             FROM subcheck_templates
-            WHERE item_type_id = ? 
+            WHERE item_type_id = ?
             AND sub_template_label = ?`)
                     .get(typeId, subcheck.subcheckName);
                 // If no template found, create one on the fly
@@ -129,11 +129,11 @@ export class InspectionManager {
                     const infoSubTemplate = db
                         .prepare(`
               INSERT INTO subcheck_templates
-                (item_type_id, 
-                sub_template_label, 
-                sub_template_description, 
-                value_type, 
-                sub_template_mandatory, 
+                (item_type_id,
+                sub_template_label,
+                sub_template_description,
+                value_type,
+                sub_template_mandatory,
                 pass_criteria)
               VALUES (?,?,?,?,?,?)`)
                         .run(typeId, subcheck.subcheckName, subcheck.subcheckDescription ?? "", dbValueType, 1, // mandatory by default
@@ -211,7 +211,7 @@ export class InspectionManager {
             inspectionId: inspectionRow.inspection_id,
             engineerId: inspectionRow.engineer_id,
             inspectionDate: inspectionRow.inspection_date, // we will set this to string in InspectionForm.ts
-            inspectionCategory: inspectionRow.category,
+            inspectionCategory: inspectionRow.inspection_category,
             itemId: inspectionRow.item_id,
             subchecks,
             comment: inspectionRow.comment ?? null,

--- a/maintenance-forms-app-prototype/maintenance_service/libraries/InspectionManager.ts
+++ b/maintenance-forms-app-prototype/maintenance_service/libraries/InspectionManager.ts
@@ -80,7 +80,7 @@ export class InspectionManager {
       const mandatoryRows = db
         .prepare(`
           SELECT
-            sub_template_label, sub_template_mandatory 
+            sub_template_label, sub_template_mandatory
           FROM subcheck_templates
           WHERE item_type_id = ?`)
         .all(typeRow.item_type_id) as Array<{ sub_template_label: string; sub_template_mandatory: 0 | 1 }>;
@@ -136,13 +136,13 @@ export class InspectionManager {
         // Try to match a template by (item_type_id, sub_template_label)
         let subcheckTemplate = db
           .prepare(`
-            SELECT 
-              sub_template_id, 
-              value_type, 
-              sub_template_mandatory, 
+            SELECT
+              sub_template_id,
+              value_type,
+              sub_template_mandatory,
               pass_criteria
             FROM subcheck_templates
-            WHERE item_type_id = ? 
+            WHERE item_type_id = ?
             AND sub_template_label = ?`)
           .get(typeId, subcheck.subcheckName) as
           | {
@@ -160,11 +160,11 @@ export class InspectionManager {
           const infoSubTemplate = db
             .prepare(`
               INSERT INTO subcheck_templates
-                (item_type_id, 
-                sub_template_label, 
-                sub_template_description, 
-                value_type, 
-                sub_template_mandatory, 
+                (item_type_id,
+                sub_template_label,
+                sub_template_description,
+                value_type,
+                sub_template_mandatory,
                 pass_criteria)
               VALUES (?,?,?,?,?,?)`
             )
@@ -276,7 +276,7 @@ export class InspectionManager {
       inspectionId: inspectionRow.inspection_id,
       engineerId: inspectionRow.engineer_id,
       inspectionDate: inspectionRow.inspection_date, // we will set this to string in InspectionForm.ts
-      inspectionCategory: inspectionRow.category,
+      inspectionCategory: inspectionRow.inspection_category,
       itemId: inspectionRow.item_id,
       subchecks,
       comment: inspectionRow.comment ?? null,


### PR DESCRIPTION
## Summary
- Align the SQLite migration so item types retain their category/description and subcheck templates/results use the `sub_*` column names that the service expects.
- Ensure the InspectionManager reads back the `inspection_category` field when reloading saved inspections.
- Refresh the compiled artifacts so the runtime migration and API handlers expose the updated column names consistently.

## Testing
- npm run build
- npm run migrate

------
https://chatgpt.com/codex/tasks/task_e_68d4e65280948321beb6dd9aa30697be